### PR TITLE
Removed reference to the Helm chart for TSorage

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,12 +50,6 @@ helm repo update
   helm install your-release-name cetic/tsaas
   ```  
   
-* [tsorage](https://github.com/cetic/helm-tsorage)
-
-  ```bash
-  helm install your-release-name cetic/tsorage
-  ```
-
 * [swaggerui](https://github.com/cetic/helm-swagger-ui)
 
   ```bash


### PR DESCRIPTION
The Helm chart for TSorage is now private, and its link should be removed.